### PR TITLE
mvar support and variable modification

### DIFF
--- a/Slax.JSON-tmLanguage
+++ b/Slax.JSON-tmLanguage
@@ -13,13 +13,13 @@
       "match": "(\\/[-a-zA-Z0-9_]+|[-a-zA-Z0-9_]+\\/[-a-zA-Z0-9_]+|\\/[-a-zA-Z0-9_]+\\/[-a-zA-Z0-9_]+)"  
     }, 
     { "name": "keyword.other.slax",
-      "match": "\\b(apply-templates|match|mode|param|priority|var|version|with|import)\\b"
+      "match": "\\b(apply-templates|match|mode|param|priority|var|mvar|version|with|import)\\b"
     },
     {  "name": "keyword.control.slax",
-       "match": "\\b(call|else|for-each|if)\\b"
+       "match": "\\b(call|else|for-each|if|set)\\b"
     },
     { "name": "meta.template.slax",
-      "match": "^\\s*(template)\\s+([-a-zA-Z0-9_:]+)\\s*\\((.*)\\)",
+      "match": "^\\s*(template|call)\\s+([-a-zA-Z0-9_:]+)\\s*\\((.*)\\)",
       "captures": {
         "1": { "name": "keyword.other.slax" },
         "2": { "name": "entity.name.function.slax" },
@@ -67,7 +67,7 @@
       "match": "\\b(copy-of|expr|import|not|ns junos|ns xnm|ns jcs)\\b"
     },
     {  "name": "variable.other.slax",
-       "match": "(\\$[-a-zA-Z0-9]+)(\\/.+)",
+       "match": "(\\$[-a-zA-Z0-9]+)(\\/[^;){\\ ]+)",
        "captures": {
            "1": { "name": "variable.other.slax" },
            "2": { "name": "markup.underline.link.slax" }

--- a/Slax.tmLanguage
+++ b/Slax.tmLanguage
@@ -34,13 +34,13 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(apply-templates|match|mode|param|priority|var|version|with|import)\b</string>
+			<string>\b(apply-templates|match|mode|param|priority|var|mvar|version|with|import)\b</string>
 			<key>name</key>
 			<string>keyword.other.slax</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(call|else|for-each|if)\b</string>
+			<string>\b(call|else|for-each|if|set)\b</string>
 			<key>name</key>
 			<string>keyword.control.slax</string>
 		</dict>
@@ -64,7 +64,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(template)\s+([-a-zA-Z0-9_:]+)\s*\((.*)\)</string>
+			<string>^\s*(template|call)\s+([-a-zA-Z0-9_:]+)\s*\((.*)\)</string>
 			<key>name</key>
 			<string>meta.template.slax</string>
 		</dict>
@@ -169,7 +169,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(\$[-a-zA-Z0-9]+)(\/.+)</string>
+			<string>(\$[-a-zA-Z0-9]+)(\/[^;){,\s]+)</string>
 			<key>name</key>
 			<string>variable.other.slax</string>
 		</dict>


### PR DESCRIPTION
- Add `mvar`, `set`, and `call` as keywords
- The color for variables were getting highlighted to the end of the line (even after the variable). Modified
  it to stop at any of these characters (or space): ;){
